### PR TITLE
:bug: feat(lang): Fixing Intl.default not-found fallback

### DIFF
--- a/__tests__/unit/src/components/events/__snapshots__/event-card.test.tsx.snap
+++ b/__tests__/unit/src/components/events/__snapshots__/event-card.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`<EventCard /> tests > should match the snapshot 1`] = `
         <time
           class="text-xs font-extrabold"
         >
-          23/1/2024, 11:16:53
+          23/1/2024, 11:16:53 a. m.
         </time>
       </div>
       <div
@@ -110,7 +110,7 @@ exports[`<EventCard /> tests > should render the optional fields if they are giv
         <time
           class="text-xs font-extrabold"
         >
-          23/1/2024, 11:16:53
+          23/1/2024, 11:16:53 a. m.
         </time>
         <div
           class="inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80"

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -13,7 +13,12 @@ export default getRequestConfig(async () => {
   const availableLocales = routing.locales;
   const defaultLocale = routing.defaultLocale;
 
-  const locale = match(languages, availableLocales, defaultLocale);
+  let locale: string;
+  try {
+    locale = match(languages, availableLocales, defaultLocale);
+  } catch {
+    locale = defaultLocale;
+  }
 
   return {
     locale,


### PR DESCRIPTION
This pull request introduces a minor localization improvement and a small robustness enhancement. The locale matching logic in `src/i18n/request.ts` has been made more resilient to errors.

Internationalization robustness:

* Improved error handling in `src/i18n/request.ts` by falling back to the default locale if locale matching fails, preventing potential runtime errors.