### PR TITLE
:white_check_mark: test(blog): add opengraph-image seo improvements

### DIFF
--- a/__tests__/unit/src/app/[lang]/blog/[slug]/opengraph-image.test.tsx
+++ b/__tests__/unit/src/app/[lang]/blog/[slug]/opengraph-image.test.tsx
@@ -1,0 +1,64 @@
+import Image, { alt, contentType, size } from '@/app/[lang]/blog/[slug]/opengraph-image';
+import { createBlogImageMetadata } from '@/lib/metadata';
+import { ImageResponse } from 'next/og';
+
+vi.mock('@/lib/metadata', () => ({
+  createBlogImageMetadata: vi.fn(),
+}));
+
+describe('opengraph-image exports', () => {
+  it('should export correct alt text', () => {
+    expect(alt).toBe('Blog');
+  });
+
+  it('should export correct image size', () => {
+    expect(size).toEqual({
+      width: 420,
+      height: 250,
+    });
+  });
+
+  it('should export correct content type', () => {
+    expect(contentType).toBe('image/jpeg');
+  });
+});
+
+describe('Image component', () => {
+  it('should generate ImageResponse with blog metadata', async () => {
+    const mockMetadata = {
+      title: 'Test Blog Post Title',
+      subtitle: 'Blog | José Duque',
+    };
+
+    vi.mocked(createBlogImageMetadata).mockResolvedValueOnce(mockMetadata);
+
+    const params = Promise.resolve({
+      slug: 'test-blog-post',
+      lang: 'en',
+    });
+
+    const result = await Image({ params });
+
+    expect(result).toBeInstanceOf(ImageResponse);
+    expect(createBlogImageMetadata).toHaveBeenCalledWith('test-blog-post', 'en');
+  });
+
+  it('should generate ImageResponse with Spanish locale', async () => {
+    const mockMetadata = {
+      title: 'Título del Post de Blog',
+      subtitle: 'Blog | José Duque',
+    };
+
+    vi.mocked(createBlogImageMetadata).mockResolvedValueOnce(mockMetadata);
+
+    const params = Promise.resolve({
+      slug: 'test-blog-post',
+      lang: 'es',
+    });
+
+    const result = await Image({ params });
+
+    expect(result).toBeInstanceOf(ImageResponse);
+    expect(createBlogImageMetadata).toHaveBeenCalledWith('test-blog-post', 'es');
+  });
+});

--- a/__tests__/unit/src/app/[lang]/blog/[slug]/page.test.tsx
+++ b/__tests__/unit/src/app/[lang]/blog/[slug]/page.test.tsx
@@ -1,4 +1,4 @@
-import { generateStaticPosts, getBlogPostBySlug } from '@/actions/blog';
+import { generateStaticPosts } from '@/actions/blog';
 import { resolveBlogPostSlug } from '@/actions/blog-post-resolver';
 import BlogPostPage, {
   generateMetadata,
@@ -36,7 +36,6 @@ vi.mock('@/i18n/routing', () => ({
 
 vi.mock('@/actions/blog', () => ({
   generateStaticPosts: vi.fn(),
-  getBlogPostBySlug: vi.fn(),
 }));
 
 vi.mock('@/lib', async (importOriginal) => ({
@@ -116,7 +115,10 @@ describe('generateStaticParams tests', () => {
 
 describe('generateMetadata tests', () => {
   it('should generate metadata for blog posts - not found', async () => {
-    vi.mocked(getBlogPostBySlug).mockResolvedValueOnce(null);
+    vi.mocked(createBlogPostMetadata).mockResolvedValueOnce({
+      title: 'Mocked blog post',
+      description: 'The requested mocked blog post was not found.',
+    });
 
     const metadata = await generateMetadata(props);
 
@@ -124,17 +126,14 @@ describe('generateMetadata tests', () => {
       title: 'Mocked blog post',
       description: 'The requested mocked blog post was not found.',
     });
-    expect(getBlogPostBySlug).toHaveBeenCalledWith(params.slug, params.lang);
-    expect(createBlogPostMetadata).not.toHaveBeenCalled();
+    expect(createBlogPostMetadata).toHaveBeenCalledWith(params.slug, params.lang);
   });
 
   it('should generate metadata for blog posts - happy path', async () => {
-    vi.mocked(getBlogPostBySlug).mockResolvedValueOnce(blogPostResultMock);
     vi.mocked(createBlogPostMetadata).mockResolvedValueOnce(metadata);
 
     await generateMetadata(props);
 
-    expect(getBlogPostBySlug).toHaveBeenCalledWith(params.slug, params.lang);
-    expect(createBlogPostMetadata).toHaveBeenCalledWith(metadata, params.lang);
+    expect(createBlogPostMetadata).toHaveBeenCalledWith(params.slug, params.lang);
   });
 });

--- a/content/blog/bienvenido-a-mi-nuevo-blog.es.mdx
+++ b/content/blog/bienvenido-a-mi-nuevo-blog.es.mdx
@@ -5,7 +5,7 @@ slugEs: bienvenido-a-mi-nuevo-blog
 title: ¡Bienvenido a mi nuevo blog!
 excerpt: Más que una simple publicación de bienvenida, esta es una introducción a mi blog, mi última migración de Vue.js a React.js (Vía Next.js) y en especial mi apreciación personal.
 category: Coding
-tags: [Migración, React, Next.js, Desarrollo web]
+tags: [Bienvenida, Migración, React, Next.js, Desarrollo web]
 publishDate: 2025-10-31T15:01:00.000Z
 readingTime: 5 minutos
 ---

--- a/content/blog/welcome-to-my-blog.en.mdx
+++ b/content/blog/welcome-to-my-blog.en.mdx
@@ -5,7 +5,7 @@ slugEs: bienvenido-a-mi-nuevo-blog
 title: Welcome to my new blog!
 excerpt: More than a simple welcome post, this is an introduction to my blog, my newest migration from Vue.js a React.js (Vía Next.js) and my personal appreciation.
 category: Coding
-tags: [Migration, React, Next.js, Web development]
+tags: [Welcome, Migration, React, Next.js, Web development]
 publishDate: 2025-10-31T15:01:00.000Z
 readingTime: 5 min
 ---

--- a/src/app/[lang]/blog/[slug]/opengraph-image.tsx
+++ b/src/app/[lang]/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,63 @@
+import { createBlogImageMetadata } from '@/lib/metadata';
+import { ImageResponse } from 'next/og';
+
+// Image metadata
+export const alt = 'Blog';
+
+export const size = {
+  width: 420,
+  height: 250,
+};
+
+export const contentType = 'image/jpeg';
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string; lang: string }>;
+}): Promise<ImageResponse> {
+  const { slug, lang } = await params;
+  const imageMetadata = await createBlogImageMetadata(slug, lang);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          height: '100%',
+          width: '100%',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+          backgroundImage:
+            'radial-gradient( circle 1292px at -13.6% 51.7%,  rgba(0,56,68,1) 0%, rgba(163,217,185,1) 51.5%, rgba(255,252,247,1) 88.6% )',
+          textAlign: 'center',
+        }}
+      >
+        <div
+          style={{
+            color: '#fff',
+            fontSize: 22,
+            marginBottom: 8,
+          }}
+        >
+          {imageMetadata.subtitle}
+        </div>
+        <div
+          style={{
+            color: '#fff',
+            fontSize: 30,
+            lineHeight: 1.2,
+            letterSpacing: -1,
+          }}
+        >
+          {imageMetadata.title}
+        </div>
+      </div>
+    ),
+    // ImageResponse options
+    {
+      ...size,
+    },
+  );
+}

--- a/src/app/[lang]/blog/[slug]/page.tsx
+++ b/src/app/[lang]/blog/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { generateStaticPosts, getBlogPostBySlug } from '@/actions/blog';
+import { generateStaticPosts } from '@/actions/blog';
 import { resolveBlogPostSlug } from '@/actions/blog-post-resolver';
 import { BlogAuthor } from '@/components/blog/blog-author';
 import { Badge } from '@/components/ui/badge';
@@ -11,17 +11,7 @@ import { getTranslations } from 'next-intl/server';
 
 export async function generateMetadata({ params }: PageProps<'/[lang]/blog/[slug]'>) {
   const { slug, lang } = await params;
-  const t = await getTranslations('Blog');
-  const result = await getBlogPostBySlug(slug, lang);
-
-  if (!result) {
-    return {
-      title: t('metadata.title'),
-      description: t('metadata.not_found_description'),
-    };
-  }
-
-  return createBlogPostMetadata(result.metadata, lang);
+  return createBlogPostMetadata(slug, lang);
 }
 
 export async function generateStaticParams() {


### PR DESCRIPTION
This pull request introduces improvements to the blog post metadata handling and adds Open Graph image generation for blog posts. The main changes include refactoring how metadata is generated for blog posts, adding a new API for generating Open Graph images with localized content, and updating tests and content tags.

**Metadata and Open Graph image generation improvements:**

* Refactored the `createBlogPostMetadata` function in `src/lib/metadata.ts` to accept `slug` and `lang` instead of a blog post object, and to internally fetch the post and handle not-found cases with localized fallback metadata. ([src/lib/metadata.tsL18-R51](diffhunk://#diff-3c90f074a2e5dffb07756fcf7fce49eb244e7cb5ec88431ae73e4d7cc6377dc8L18-R51), [src/app/[lang]/blog/[slug]/page.tsxL14-R14](diffhunk://#diff-10e28087ab5a4421acdec14f431f779c12abb731d3c255cee766c344b7a92664L14-R14))
* Added a new `createBlogImageMetadata` function in `src/lib/metadata.ts` to generate image metadata (title and subtitle) for Open Graph images based on the blog post slug and language.
* Implemented the Open Graph image API in `src/app/[lang]/blog/[slug]/opengraph-image.tsx`, which uses the new metadata function and returns a localized image using `ImageResponse`. ([src/app/[lang]/blog/[slug]/opengraph-image.tsxR1-R63](diffhunk://#diff-0a132615c7d9ce19c56e2d7a80ad0cca4c5f686d4de83c021b07e1b86fcfbba2R1-R63))

**Testing updates:**

* Added unit tests for the Open Graph image API and exports in `__tests__/unit/src/app/[lang]/blog/[slug]/opengraph-image.test.tsx`. ([__tests__/unit/src/app/[lang]/blog/[slug]/opengraph-image.test.tsxR1-R64](diffhunk://#diff-aae36196f9ae98a6897dd7718e7bf9c0c252642e3ddfc9b9ee898afa55fb693dR1-R64))
* Updated tests in `__tests__/unit/src/app/[lang]/blog/[slug]/page.test.tsx` to mock and use the new metadata API, removing references to the old `getBlogPostBySlug` usage. 